### PR TITLE
Use BUILD_SHARED_LIBS to build shared libraries

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,6 @@
 {
   "project_name": "my_project",
   "class_name": "MyClass",
-  "library_type": ["shared", "static"],
   "ros2_version": "rolling",
   "project_short_description": "TODO: Project Short Description",
   "author": "John Doe",

--- a/{{ cookiecutter.project_name | snakecase }}/CMakeLists.txt
+++ b/{{ cookiecutter.project_name | snakecase }}/CMakeLists.txt
@@ -6,6 +6,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     -Wsign-conversion -Winit-self -Wredundant-decls)
 endif()
 
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp
   eigen3_cmake_module

--- a/{{ cookiecutter.project_name | snakecase }}/CMakeLists.txt
+++ b/{{ cookiecutter.project_name | snakecase }}/CMakeLists.txt
@@ -23,7 +23,7 @@ endforeach()
 
 # Declare a C++ library
 add_library(
-  ${PROJECT_NAME} {{ 'SHARED' if cookiecutter.library_type == 'shared' else '' }}
+  ${PROJECT_NAME}
   src/{{ cookiecutter.class_name | snakecase }}.cpp
 )
 ament_target_dependencies(${PROJECT_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})


### PR DESCRIPTION
- Revert "Add option to select library build type and default to shared"
- Use BUILD_SHARED_LIBS to build shared libraries
